### PR TITLE
updates for predictions support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,9 @@ RUN curl -fsSL https://code-server.dev/install.sh | sh
 # install ansible extension
 RUN code-server --install-extension redhat.ansible 
 
+# set up work directory for vs-code
+RUN mkdir -p workspace && touch workspace/playbook.yaml
+
 
 # enable FIPS mode for NSS
 RUN modutil -fips true -dbdir /etc/pki/nssdb -force && \

--- a/init.go
+++ b/init.go
@@ -91,6 +91,7 @@ func startSelenium() *exec.Cmd {
 func startCodeServer() *exec.Cmd {
 	vscode := exec.Command(
 		"code-server",
+		"./workspace",
 		"--auth",
 		"none",
 	)


### PR DESCRIPTION
as this container is mainly used to test the ansible extension, this PR adds the playbook.ymal file as a playbook to be used for testing, as well as setting the folder of vs-code to `workspace`.

with this, when vs-code is accessed, it will already be in a directory with a yaml file 