### PR TITLE
improve start time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,5 +178,8 @@ RUN chown -R 1001:0 ${SELENIUM_HOME} && \
 
 USER 1001
 
+# install packages needed for go file
+RUN go vet /init.go
+
 # run init.go to start all process in order
 CMD ["sh", "-c", "go run /init.go" ]


### PR DESCRIPTION
added a building step to install needed packages for the init.go file with it, the init file can start immediately when running the container instead of having to wait for the packages to be downladed